### PR TITLE
Add automatic sitemap discovery and recursive parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,8 @@ pip3 install -r requirements.txt
 python3 linksOnPage2pdf.py https://example.com --same-origin
 
 # Crawl links listed in a sitemap.xml
+# Pass a sitemap.xml directly
 python3 linksInSitemap2pdf.py https://example.com/sitemap.xml
+
+# Or let the script discover the sitemap from the site's root
+python3 linksInSitemap2pdf.py https://example.com


### PR DESCRIPTION
## Summary
- add helper to discover sitemap URL via direct path or robots.txt
- allow recursive parsing of sitemap indexes
- extend linksInSitemap2pdf to accept a site root and auto-discover sitemap
- update README with new usage examples

## Testing
- `python -m py_compile site2pdf_core.py linksInSitemap2pdf.py linksOnPage2pdf.py`
- `python linksInSitemap2pdf.py https://invertedpassion.com --limit 1 --delay 0.1` *(fails: Sitemap URL not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88cc0ad688328ace7be7ce8a41de7